### PR TITLE
fix: guard itemName:match against nil from uncached items

### DIFF
--- a/AlreadyKnown.lua
+++ b/AlreadyKnown.lua
@@ -271,7 +271,7 @@ local _G = _G
 		if classId == Enum.ItemClass.Miscellaneous then
 			local itemName = C_Item.GetItemInfo(itemId)
 			local itemNameBrackets
-			if itemName:match("%((%a+)%)") then
+			if itemName and itemName:match("%((%a+)%)") then
 				local basicName, bracketInformation = itemName:match("([%a%s]+) %((%a+)%)")
 				basicName = strtrim(basicName)
 				itemNameBrackets = bracketInformation .. " " .. basicName

--- a/AlreadyKnownClassic.lua
+++ b/AlreadyKnownClassic.lua
@@ -324,7 +324,7 @@ local _G = _G
 			elseif classId == Enum.ItemClass.Miscellaneous and subclassId == Enum.ItemMiscellaneousSubclass.CompanionPet then -- CompanionPet
 				local itemName = C_Item.GetItemInfo(itemId)
 				local itemNameBrackets
-				if itemName:match("%((%a+)%)") then
+				if itemName and itemName:match("%((%a+)%)") then
 					local basicName, bracketInformation = itemName:match("([%a%s]+) %((%a+)%)")
 					basicName = strtrim(basicName)
 					itemNameBrackets = bracketInformation .. " " .. basicName
@@ -356,7 +356,7 @@ local _G = _G
 			local numCompanions = GetNumCompanions("CRITTER")
 			local itemName = C_Item.GetItemInfo(itemId)
 			local itemNameBrackets
-			if itemName:match("%((%a+)%)") then
+			if itemName and itemName:match("%((%a+)%)") then
 				local basicName, bracketInformation = itemName:match("([%a%s]+) %((%a+)%)")
 				basicName = strtrim(basicName)
 				itemNameBrackets = bracketInformation .. " " .. basicName


### PR DESCRIPTION
### Problem

`C_Item.GetItemInfo(itemId)` can return `nil` for a nameless/uncached item, and the bracket-name parsing calls `itemName:match(...)` **before** the existing `if itemName then` guard a few lines below. That raises `attempt to index local 'itemName' (a nil value)`.

Reproduced from the Guild Bank hook with an empty-name junk item (itemID `25409`):

```
2x AlreadyKnown/AlreadyKnown.lua:274: attempt to index local 'itemName' (a nil value)
[AlreadyKnown/AlreadyKnown.lua]:274: in function <AlreadyKnown/AlreadyKnown.lua:212>
[AlreadyKnown/AlreadyKnown.lua]:437: in function <AlreadyKnown/AlreadyKnown.lua:410>
[C]: in function 'Update'
[Blizzard_GuildBankUI/Blizzard_GuildBankUI.lua]:613: in function 'OnClick'
...
Locals:
itemLink="|cnIQ1:|Hitem:25409::::::::80:105:::::::::|h[]|h|r"
itemId=25409
itemName=nil
```

The same unguarded pattern exists in the Classic file (two CompanionPet paths).

### Fix

Add an `itemName and` short-circuit to the bracket-name `:match` in `AlreadyKnown.lua` and both spots in `AlreadyKnownClassic.lua`. When the name isn't available, `itemNameBrackets` stays `nil` and the existing `if itemName then` block already handles the rest, so behavior is unchanged for cached items.